### PR TITLE
Truncate even if the element height is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Truncator
-Simple text truncator that truncate by line count, content height or character count.
+Layout specific text truncator considering line length, content height or character length.
 
-## Install
+## Installation
 Install from npm.
 
 ```sh

--- a/src/truncator.js
+++ b/src/truncator.js
@@ -64,7 +64,7 @@ function truncateImpl(el, text, maxHeight, options, left, right) {
   const truncated = text.substring(0, center) + options.ellipsis;
   el.text = truncated;
 
-  if (left + 1 >= right) {
+  if (left >= right - 1) {
     return;
   }
 

--- a/src/truncator.js
+++ b/src/truncator.js
@@ -10,22 +10,24 @@ export function truncate(el, text, options) {
     throw new Error('options must be an object');
   }
 
-  const domEl = dom(el);
-  const opts = normalizeOptions(options);
+  execWithUnfixHeight(el, () => {
+    const domEl = dom(el);
+    const opts = normalizeOptions(options);
 
-  if (typeof opts.height === 'number') {
-    return truncateByHeight(domEl, text, opts.height, opts);
-  }
+    if (typeof opts.height === 'number') {
+      return truncateByHeight(domEl, text, opts.height, opts);
+    }
 
-  if (typeof opts.line === 'number') {
-    return truncateByLine(domEl, text, Math.floor(opts.line), opts);
-  }
+    if (typeof opts.line === 'number') {
+      return truncateByLine(domEl, text, Math.floor(opts.line), opts);
+    }
 
-  if (typeof opts.count === 'number') {
-    return truncateByCount(domEl, text, Math.floor(opts.count), opts);
-  }
+    if (typeof opts.count === 'number') {
+      return truncateByCount(domEl, text, Math.floor(opts.count), opts);
+    }
 
-  throw new Error('options must have height, line or count as number');
+    throw new Error('options must have height, line or count as number');
+  });
 }
 
 function normalizeOptions(options) {
@@ -34,6 +36,26 @@ function normalizeOptions(options) {
   if (opts.ellipsis === null) opts.ellipsis = '';
 
   return opts;
+}
+
+// set the element height to auto
+// and unlock constraints of min-, max-height during given function is executed
+function execWithUnfixHeight(el, fn) {
+  const {height, maxHeight, minHeight} = el.style;
+
+  try {
+    el.style.height = 'auto';
+    el.style.maxHeight = 'none';
+    el.style.minHeight = '0';
+
+    fn();
+
+  } finally {
+    // ensure the styles are restored
+    el.style.height = height;
+    el.style.maxHeight = maxHeight;
+    el.style.minHeight = minHeight;
+  }
 }
 
 function truncateByLine(el, text, line, options) {

--- a/src/truncator.js
+++ b/src/truncator.js
@@ -6,12 +6,8 @@ const DEFAULT_OPTIONS = {
 };
 
 export function truncate(el, text, options) {
-  if (typeof options === 'number') {
-    return truncateByHeight(el, text, options);
-  }
-
   if (options === null || typeof options !== 'object') {
-    throw new Error('options must be number or object');
+    throw new Error('options must be an object');
   }
 
   const domEl = dom(el);

--- a/test/truncator_test.js
+++ b/test/truncator_test.js
@@ -61,6 +61,39 @@ describe('truncate methods', () => {
 
       assert(el.innerHTML === expected);
     });
+
+    it('should truncate even if the element height is fixed', () => {
+      truncate(el, input, { height: 30 });
+      expected = el.innerHTML;
+
+      el.style.height = '1000px';
+      truncate(el, input, { height: 30 });
+
+      assert(el.innerHTML === expected);
+      assert(el.style.height === '1000px');
+    });
+
+    it('should truncate even if max-height is set', () => {
+      truncate(el, input, { height: 30 });
+      expected = el.innerHTML;
+
+      el.style.maxHeight = '10px';
+      truncate(el, input, { height: 30 });
+
+      assert(el.innerHTML === expected);
+      assert(el.style.maxHeight === '10px');
+    });
+
+    it('should truncate even if min-height is set', () => {
+      truncate(el, input, { height: 30 });
+      expected = el.innerHTML;
+
+      el.style.minHeight = '1000px';
+      truncate(el, input, { height: 30 });
+
+      assert(el.innerHTML === expected);
+      assert(el.style.minHeight === '1000px');
+    });
   });
 
   describe('Truncate options', () => {


### PR DESCRIPTION
Includes minor refactoring and the update of expecting option type.
Truncator only expects an `object` value as an option argument.

fix #5 
