### PR TITLE
Allow re-truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ var truncate = Truncator.truncate;
 
 ## Usage
 
+Just call `truncate` function then the specified text will be truncated.
+
 ```js
-truncate(el, text, options);
+var truncator = truncate(el, text, options);
 ```
 
 - `el`: `HTMLElement` that will be input `text`.
@@ -42,12 +44,23 @@ truncate(el, text, options);
   - `line`, `height` or `count`
   - `ellipsis`: Ellipsis symbol. `null` indicates no symbol will be added. default: `'...'`
 
+The returned object has `recalc()` method that retry to truncate the initially given `el` and `text` on the current state. It is useful if you want to adapt resizing the container element.
+
+```js
+truncator.recalc();
+```
+
 ### Example
 
 ```js
 var el = document.getElementById('wrapper');
-truncate(el, 'Target text', { line: 3, ellipsis: null });
+var truncator = truncate(el, 'Target text', { line: 3, ellipsis: null });
+
+window.addEventListener('resize', function () {
+  truncator.recalc();
+});
 ```
 
 ## License
+
 MIT

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-export * from './truncator'
+export { truncate } from './truncator'

--- a/src/truncator.js
+++ b/src/truncator.js
@@ -5,29 +5,45 @@ const DEFAULT_OPTIONS = {
   ellipsis: '...'
 }
 
+export class Truncator {
+  constructor (el, text, boundary, options, truncate) {
+    this.el = el
+    this.text = text
+    this.boundary = boundary
+    this.options = options
+    this.truncate = truncate
+
+    this.recalc()
+  }
+
+  recalc () {
+    execWithUnfixHeight(this.el.el, () => {
+      this.truncate(this.el, this.text, this.boundary, this.options)
+    })
+  }
+}
+
 export function truncate(el, text, options) {
   if (options === null || typeof options !== 'object') {
     throw new Error('options must be an object')
   }
 
-  execWithUnfixHeight(el, () => {
-    const domEl = dom(el)
-    const opts = normalizeOptions(options)
+  const domEl = dom(el)
+  const opts = normalizeOptions(options)
 
-    if (typeof opts.height === 'number') {
-      return truncateByHeight(domEl, text, opts.height, opts)
-    }
+  if (typeof opts.height === 'number') {
+    return new Truncator(domEl, text, opts.height, opts, truncateByHeight)
+  }
 
-    if (typeof opts.line === 'number') {
-      return truncateByLine(domEl, text, Math.floor(opts.line), opts)
-    }
+  if (typeof opts.line === 'number') {
+    return new Truncator(domEl, text, Math.floor(opts.line), opts, truncateByLine)
+  }
 
-    if (typeof opts.count === 'number') {
-      return truncateByCount(domEl, text, Math.floor(opts.count), opts)
-    }
+  if (typeof opts.count === 'number') {
+    return new Truncator(domEl, text, Math.floor(opts.count), opts, truncateByCount)
+  }
 
-    throw new Error('options must have height, line or count as number')
-  })
+  throw new Error('options must have height, line or count as number')
 }
 
 function normalizeOptions(options) {

--- a/test/truncator_test.js
+++ b/test/truncator_test.js
@@ -1,6 +1,6 @@
 import assert from 'power-assert'
 
-import { truncate } from '../src/truncator'
+import { truncate, Truncator } from '../src/truncator'
 
 describe('truncate methods', () => {
   let el, expected
@@ -116,6 +116,27 @@ describe('truncate methods', () => {
       truncate(el, input, { count: 10, ellipsis: undefined })
 
       assert(el.innerHTML === expected)
+    })
+  })
+
+  describe('Truncator model', () => {
+    it('recalculate the truncation', () => {
+      let callCount = 0
+
+      const stubEl = { el }
+
+      const mock = (el, text, boundary, options) => {
+        assert.deepStrictEqual(el, stubEl)
+        assert(text === input)
+        assert(boundary === 10)
+        assert.deepStrictEqual(options, { ellipsis: '...' })
+        callCount += 1
+      }
+
+      const t = new Truncator(stubEl, input, 10, { ellipsis: '...' }, mock)
+      assert(callCount === 1) // initial truncation
+      t.recalc()
+      assert(callCount === 2)
     })
   })
 })


### PR DESCRIPTION
This PR allows us to re-truncate specified `el` and `text`.
This is useful if we want to update the truncated text by resizing the container element.