### PR TITLE
feat: add restoreText method on a trancator instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,17 @@ var truncator = truncate(el, text, options);
   - `line`, `height` or `count`
   - `ellipsis`: Ellipsis symbol. `null` indicates no symbol will be added. default: `'...'`
 
-The returned object has `recalc()` method that retry to truncate the initially given `el` and `text` on the current state. It is useful if you want to adapt resizing the container element.
+The returned object has the following methods:
+
+- `recalc()`: Retry to truncate the initially given `el` and `text` on the current state. It is useful if you want to adapt resizing the container element.
+- `restoreText()`: Restore the original text on `el`.
 
 ```js
+// Re-truncate the text
 truncator.recalc();
+
+// Restore the original text
+truncator.restoreText();
 ```
 
 ### Example

--- a/src/truncator.js
+++ b/src/truncator.js
@@ -21,6 +21,10 @@ export class Truncator {
       this.truncate(this.el, this.text, this.boundary, this.options)
     })
   }
+
+  restoreText () {
+    this.el.text = this.text
+  }
 }
 
 export function truncate(el, text, options) {

--- a/test/truncator_test.js
+++ b/test/truncator_test.js
@@ -138,5 +138,13 @@ describe('truncate methods', () => {
       t.recalc()
       assert(callCount === 2)
     })
+
+    it('restore the original text', () => {
+      const t = truncate(el, input, { count: 10 })
+
+      assert(el.innerHTML === 'Grumpy wiz...')
+      t.restoreText()
+      assert(el.innerHTML === input)
+    })
   })
 })


### PR DESCRIPTION
This adds `restoreText` method on truncator instance. It would be useful if the user want to temporally disable truncation in some situations.